### PR TITLE
Add MarkdownTable

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version=false

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can get a couple of Markdown-specific helpers from the `stylelint-formatter-
 
 ```js
 const {MarkdownTable, link} = require('stylelint-formatter-utils/markdown')
-const table = new Table({
+const table = new MarkdownTable({
   columns: [
     {title: 'rule', format: ({rule}) => {
       return link(rule, `https://stylelint.io/user-guide/rules/${rule}`)

--- a/README.md
+++ b/README.md
@@ -28,27 +28,8 @@ console.log(table.format([
 // y.css,5
 ```
 
-Want to generate a Markdown table? Easy peazy:
+Want to generate a Markdown table? Get it from the [markdown exports](#markdown).
 
-```js
-const markdown = new Table({
-  columns: [
-    {title: 'rule', format: ({rule}) => {
-      return link(rule, `https://stylelint.io/user-guide/rules/${rule}`)
-    }},
-    {title: 'path', format: ({source, line}) => {
-      return link(`${source}@${line}`, `https://github.com/my/repo/blob/master/${source}#L${line}`)
-    }}
-  ],
-  delimiter: ' | ',
-  beforeLine: '| ',
-  afterLine: ' |'
-})
-
-function link(text, url) {
-  return `[${text}](${url})`
-}
-```
 
 ## `getHeadRef()`
 Get the git head ref, which is useful for generating links to source code.
@@ -76,3 +57,28 @@ If `cwd` is not provided or empty, we get it from `process.cwd()`.
 const {stripCwd} = require('stylelint-formatter-utils')
 console.log(`this file is: ${stripCwd(__filename)}`)
 ```
+
+## Markdown
+You can get a couple of Markdown-specific helpers from the `stylelint-formatter-utils/markdown` endpoint:
+
+### MarkdownTable
+
+```js
+const {MarkdownTable, link} = require('stylelint-formatter-utils/markdown')
+const table = new Table({
+  columns: [
+    {title: 'rule', format: ({rule}) => {
+      return link(rule, `https://stylelint.io/user-guide/rules/${rule}`)
+    }},
+    {title: 'path', format: ({source, line}) => {
+      return link(`${source}@${line}`, `https://github.com/my/repo/blob/master/${source}#L${line}`)
+    }}
+  ]
+})
+```
+
+### `markdown.link(text, url)`
+Returns a Markdown link in the format `[text](url)`.
+
+### `markdown.code(text)`
+Returns the string wrapped in backticks.

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 const {spawnSync} = require('child_process')
 const getOriginURL = require('remote-origin-url').sync
 const parseGitURL = require('git-url-parse')
-const markdown = require('./markdown')
 
 module.exports = {
   getHeadRef,
   getRepoURL,
   stripCwd,
   Table,
-  markdown
+  markdown: require('./markdown')
 }
 
 function getHeadRef() {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   getHeadRef,
   getRepoURL,
   stripCwd,
-  Table,
+  Table: require('./table'),
   markdown: require('./markdown')
 }
 

--- a/index.js
+++ b/index.js
@@ -1,26 +1,14 @@
 const {spawnSync} = require('child_process')
 const getOriginURL = require('remote-origin-url').sync
 const parseGitURL = require('git-url-parse')
-const Table = require('./table')
-
-class MarkdownTable extends Table {
-  constructor({columns}) {
-    super({
-      delimiter: ' | ',
-      beforeLine: '| ',
-      afterLine: ' |',
-      afterHeaderPlaceholder: ':---',
-      columns
-    })
-  }
-}
+const markdown = require('./markdown')
 
 module.exports = {
   getHeadRef,
   getRepoURL,
   stripCwd,
   Table,
-  MarkdownTable
+  markdown
 }
 
 function getHeadRef() {

--- a/index.js
+++ b/index.js
@@ -3,11 +3,24 @@ const getOriginURL = require('remote-origin-url').sync
 const parseGitURL = require('git-url-parse')
 const Table = require('./table')
 
+class MarkdownTable extends Table {
+  constructor({columns}) {
+    super({
+      delimiter: ' | ',
+      beforeLine: '| ',
+      afterLine: ' |',
+      afterHeaderPlaceholder: ':---',
+      columns
+    })
+  }
+}
+
 module.exports = {
   getHeadRef,
   getRepoURL,
   stripCwd,
-  Table
+  Table,
+  MarkdownTable
 }
 
 function getHeadRef() {

--- a/markdown.js
+++ b/markdown.js
@@ -1,0 +1,29 @@
+const Table = require('./table')
+
+const tableOptions = {
+  delimiter: ' | ',
+  beforeLine: '| ',
+  afterLine: ' |',
+  afterHeaderPlaceholder: ':---'
+}
+
+class MarkdownTable extends Table {
+  constructor(options) {
+    super(Object.assign({}, tableOptions, options))
+  }
+}
+
+module.exports = {
+  tableOptions,
+  MarkdownTable,
+  link,
+  code
+}
+
+function link(text, url) {
+  return `[${text}](${url})`
+}
+
+function code(str) {
+  return `\`${str}\``
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-formatter-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-formatter-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/table.js
+++ b/table.js
@@ -1,17 +1,37 @@
 module.exports = class Table {
   constructor(options = {}) {
-    const {columns = [], delimiter = '\t', lineDelimiter = '\n', beforeLine = '', afterLine = ''} = options
+    const {
+      columns = [],
+      delimiter = '\t',
+      lineDelimiter = '\n',
+      beforeLine = '',
+      afterLine = '',
+      beforeHeaderPlaceholder,
+      afterHeaderPlaceholder,
+    } = options
     Object.assign(this, {
       columns,
       delimiter,
       lineDelimiter,
       beforeLine,
-      afterLine
+      afterLine,
+      beforeHeaderPlaceholder,
+      afterHeaderPlaceholder
     })
   }
 
   header() {
-    return this.columns.map(column => this.heading(column)).join(this.delimiter)
+    let header = this.columns.map(column => this.heading(column)).join(this.delimiter)
+    header = this.wrapLine(header)
+    if (this.beforeHeaderPlaceholder) {
+      const before = this.columns.map(() => this.beforeHeaderPlaceholder).join(this.delimiter)
+      header = this.wrapLine(before) + this.lineDelimiter + header
+    }
+    if (this.afterHeaderPlaceholder) {
+      const after = this.columns.map(() => this.afterHeaderPlaceholder).join(this.delimiter)
+      header += this.lineDelimiter + this.wrapLine(after)
+    }
+    return header
   }
 
   heading(column) {
@@ -21,7 +41,11 @@ module.exports = class Table {
   row(row) {
     const cells = this.columns.map(column => this.cell(column, row))
     const content = cells.map(cell => this.escape(cell)).join(this.delimiter)
-    return `${this.beforeLine}${content}${this.afterLine}`
+    return this.wrapLine(content)
+  }
+
+  wrapLine(content) {
+    return `${this.beforeLine || ''}${content}${this.afterLine || ''}`
   }
 
   cell(column, row) {

--- a/table.js
+++ b/table.js
@@ -7,7 +7,7 @@ module.exports = class Table {
       beforeLine = '',
       afterLine = '',
       beforeHeaderPlaceholder,
-      afterHeaderPlaceholder,
+      afterHeaderPlaceholder
     } = options
     Object.assign(this, {
       columns,


### PR DESCRIPTION
This adds a suite of Markdown utilities:

```js
const {MarkdownTable, code, link} = require('stylelint-formatter-utils/markdown')
const table = new MarkdownTable({
  columns: [
    {title: 'rule', format: ({rule}) => link(rule, `https://stylelint.io/user-guide/rules/${rule}`)},
    {title: 'path', format: ({source, line}) => code(`${source}:${line}`)}
  ]
})
```